### PR TITLE
use path/filepath to join the cache path. 

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"strings"
+	"path/filepath"
 )
 
-var cachePath = path.Join(os.TempDir(), "pullkee_cache", "cache.json")
+var cachePath = filepath.Join(os.TempDir(), "pullkee_cache", "cache.json")
 
 // Cache is an interface for a Get/Set caching struct
 type Cache interface {
@@ -60,5 +60,5 @@ func (c FSCache) Get(key string, x interface{}) (bool, error) {
 }
 
 func (c FSCache) filePath(key string) string {
-	return path.Join(c.CachePath, fmt.Sprintf("%s.json", key))
+	return filepath.Join(c.CachePath, fmt.Sprintf("%s.json", key))
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"time"
@@ -58,7 +58,7 @@ func getAPI(client client.HTTPClient, repo string) github.APIv3 {
 
 func getCache(repo string) cache.Cache {
 	return cache.FSCache{
-		CachePath: path.Join(os.TempDir(), "pullkee_cache", repo),
+		CachePath: filepath.Join(os.TempDir(), "pullkee_cache", repo),
 		FS:        RealFS{},
 	}
 }


### PR DESCRIPTION
This will use the path separator that's native to the OS. Partially addressing #1 
There seem to be more errors related to the caching.
